### PR TITLE
fix: Disable auto-filling of country name in tax popup (#5286)

### DIFF
--- a/app/templates/components/modals/tax-info-modal.hbs
+++ b/app/templates/components/modals/tax-info-modal.hbs
@@ -6,7 +6,7 @@
     <div class="field">
       <label class="required">{{t 'Choose country'}}</label>
       <UiDropdown @class="search selection" @selected={{this.tax.country}} @forceSelection={{false}} @fullTextSearch={{true}}>
-        <Input @type="hidden" @autocomplete="no" @id="tax_country" @value={{this.tax.country}} />
+        <Input @type="hidden" @autocomplete="tax-country" @id="tax_country" @value={{this.tax.country}} />
         <i class="dropdown icon"></i>
         <div class="default text">{{t 'Select country'}}</div>
         <div class="menu">


### PR DESCRIPTION
* Disabled auto-filling of information during Tax Pop-up in wizard step-1

* replaced placeholder string by respective field name in autocomplete attribute

* placeholder replaced by country in autocomplete attribute

* changed the autocomplete attribute of input feilds

* removed extra space from input attributes

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
